### PR TITLE
Deduplicate data fetches in grex and registrant layouts

### DIFF
--- a/app/(default)/[genus]/[...genusRouteParams]/page.tsx
+++ b/app/(default)/[genus]/[...genusRouteParams]/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cache } from 'react';
 
 import { Grex } from 'lib/types';
 import { fetchGrex } from 'lib/fetchers/grex';
@@ -38,7 +38,7 @@ const fetchGrexByName = async ({
   }
 };
 
-export async function maybeGetGrex(g: string, e: string, id: string) {
+export const maybeGetGrex = cache(async function maybeGetGrex(g: string, e: string, id: string) {
   let grex: Grex | undefined;
   if (parseInt(id, 10)) {
     [grex] = await fetchGrex(id);
@@ -46,7 +46,7 @@ export async function maybeGetGrex(g: string, e: string, id: string) {
     grex = await fetchGrexByName({ genus: g, epithet: e });
   }
   return grex;
-}
+});
 
 export type GrexPageParams = Promise<{
   genus: string;

--- a/app/(default)/registrant/[r]/layout.tsx
+++ b/app/(default)/registrant/[r]/layout.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { Metadata } from 'next';
 import React from 'react';
 
@@ -54,12 +55,12 @@ const buildDescription = (
   return `${desc}.`;
 };
 
-export async function fetchRegistrant(name: string): Promise<object[]> {
+export const fetchRegistrant = cache(async (name: string): Promise<object[]> => {
   const res = await fetch(
     `${APP_URL}/api/registrant/${encodeURIComponent(name)}`
   );
   return res.json();
-}
+});
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
## Summary
- Wrap `maybeGetGrex` with React `cache()` so the grex layout's `generateMetadata` and page component share a single fetch per request
- Wrap `fetchRegistrant` with React `cache()` to eliminate the same duplication on registrant pages

## Test plan
- [ ] Verify grex detail pages (`/[genus]/[epithet]/[id]`) still render correctly with metadata
- [ ] Verify registrant pages (`/registrant/[name]`) still render correctly with metadata
- [ ] Confirm no duplicate API calls in server logs for these routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)