### PR TITLE
Replace self-referential HTTP fetches with direct DB queries

### DIFF
--- a/app/(default)/[genus]/[...genusRouteParams]/page.tsx
+++ b/app/(default)/[genus]/[...genusRouteParams]/page.tsx
@@ -1,9 +1,9 @@
 import React, { cache } from 'react';
 
 import { Grex } from 'lib/types';
-import { fetchGrex } from 'lib/fetchers/grex';
+import { queryGrexById } from 'lib/queries/grex';
 import { UNKNOWN_CHAR, repairMalformedNaturalHybridEpithet } from 'lib/string';
-import { APP_URL } from 'lib/constants';
+import { querySearch } from 'lib/queries/search';
 import { find } from 'lodash';
 import GrexView from './view';
 
@@ -19,10 +19,10 @@ const fetchGrexByName = async ({
     : `"${repairMalformedNaturalHybridEpithet({ epithet })}"`;
 
   try {
-    const fetched = await fetch(
-      `${APP_URL}/api/search?genus=${quotedGenus}&epithet=${quotedEpithet}`
-    );
-    const json = await fetched.json();
+    const json = await querySearch({
+      genus: quotedGenus,
+      epithet: quotedEpithet,
+    });
 
     let match: Grex;
 
@@ -41,7 +41,7 @@ const fetchGrexByName = async ({
 export const maybeGetGrex = cache(async function maybeGetGrex(g: string, e: string, id: string) {
   let grex: Grex | undefined;
   if (parseInt(id, 10)) {
-    [grex] = await fetchGrex(id);
+    [grex] = await queryGrexById(id);
   } else if (g && e) {
     grex = await fetchGrexByName({ genus: g, epithet: e });
   }

--- a/app/(default)/learn/hybridize/page.tsx
+++ b/app/(default)/learn/hybridize/page.tsx
@@ -1,9 +1,8 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
-import { fetchGrex } from 'lib/fetchers/grex';
+import { queryGrexById, queryGrexChild } from 'lib/queries/grex';
 import { Grex, Grex as GrexType } from 'lib/types';
 import GrexView from 'app/(default)/[genus]/[...genusRouteParams]/view';
-import { fetchGrexChild } from 'lib/fetchers/grex-child';
 import { formatName } from 'lib/string';
 import Form from './form';
 
@@ -25,7 +24,7 @@ export async function generateMetadata({
     };
   }
 
-  const [sGrex, pGrex] = await fetchGrex(`${s},${p}`);
+  const [sGrex, pGrex] = await queryGrexById(`${s},${p}`);
 
   const sName = formatName(sGrex).short.full;
   const pName = formatName(pGrex).short.full;
@@ -50,17 +49,17 @@ export default async function Hybridize({
   const pId = parseInt(p as string, 10);
 
   if (sId && pId) {
-    const parents = await fetchGrex(`${sId},${pId}`);
+    const parents = await queryGrexById(`${sId},${pId}`);
     selectedSeedParent = parents.find((parent) => parent.id === s);
     selectedPollenParent = parents.find((parent) => parent.id === p);
   } else if (sId) {
-    [selectedSeedParent] = await fetchGrex(s);
+    [selectedSeedParent] = await queryGrexById(s);
   } else if (pId) {
-    [selectedPollenParent] = await fetchGrex(p);
+    [selectedPollenParent] = await queryGrexById(p);
   }
 
   if (s && p) {
-    [existingGrex] = await fetchGrexChild(s as string, p as string);
+    [existingGrex] = await queryGrexChild(s as string, p as string);
   }
 
   // useSearchParams needs <Suspense />

--- a/app/(default)/registrant/[r]/layout.tsx
+++ b/app/(default)/registrant/[r]/layout.tsx
@@ -3,7 +3,8 @@ import { Metadata } from 'next';
 import React from 'react';
 
 import { Grex } from 'lib/types';
-import { APP_TITLE, APP_URL } from 'lib/constants';
+import { APP_TITLE } from 'lib/constants';
+import { queryRegistrant } from 'lib/queries/registrant';
 
 import { createRegistrantStatMap, StatMap } from './utils';
 
@@ -56,10 +57,7 @@ const buildDescription = (
 };
 
 export const fetchRegistrant = cache(async (name: string): Promise<object[]> => {
-  const res = await fetch(
-    `${APP_URL}/api/registrant/${encodeURIComponent(name)}`
-  );
-  return res.json();
+  return queryRegistrant(name);
 });
 
 export async function generateMetadata({

--- a/app/api/grex/route.ts
+++ b/app/api/grex/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ID_FIELDS, SEARCH_FIELDS } from 'lib/constants';
-import { query } from 'lib/storage/pg';
+import { queryGrexById } from 'lib/queries/grex';
 
 export async function GET(req: NextRequest) {
   const { id: idParam } = Object.fromEntries(req.nextUrl.searchParams);
 
-  const json = await query(
-    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(
-      ', '
-    )} FROM rhs WHERE id = ANY('{${idParam}}'::text[])`
-  );
+  const json = await queryGrexById(idParam);
 
   return NextResponse.json(json, { status: 200 });
 }

--- a/app/api/grexChild/route.ts
+++ b/app/api/grexChild/route.ts
@@ -1,16 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ID_FIELDS, SEARCH_FIELDS } from 'lib/constants';
-import { query } from 'lib/storage/pg';
+import { queryGrexChild } from 'lib/queries/grex';
 
 export async function GET(req: NextRequest) {
   const { s, p } = Object.fromEntries(req.nextUrl.searchParams);
-  const idArrayItems = [s, p].join(',');
 
-  const json = await query(
-    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(
-      ', '
-    )} FROM rhs WHERE seed_parent_id = ANY('{${idArrayItems}}'::text[]) AND pollen_parent_id = ANY('{${idArrayItems}}'::text[])`
-  );
+  const json = await queryGrexChild(s, p);
 
   return NextResponse.json(json, { status: 200 });
 }

--- a/app/api/registrant/[name]/route.ts
+++ b/app/api/registrant/[name]/route.ts
@@ -1,22 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ID_FIELDS, SEARCH_FIELDS } from 'lib/constants';
-import { query } from 'lib/storage/pg';
+import { queryRegistrant } from 'lib/queries/registrant';
 
 type Params = Promise<{ name: string }>;
 
 export async function GET(req: NextRequest, { params }: { params: Params }) {
-  const { name: raw } = await params;
-  const r = raw.replace(/'/g, "''");
+  const { name } = await params;
 
-  if (!r) {
-    return NextResponse.json([], { status: 200 });
-  }
-
-  const json = await query(
-    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(
-      ', '
-    )} FROM rhs WHERE epithet != '' AND (registrant_name = '${r}' OR originator_name = '${r}') ORDER BY date_of_registration DESC`
-  );
+  const json = await queryRegistrant(name);
 
   return NextResponse.json(json, { status: 200 });
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SEARCH_FIELDS, CROSS_FIELDS } from 'lib/constants';
-import { formatClause, makeCrossQuery } from 'lib/utils';
-import { query } from 'lib/storage/pg';
+import { querySearch } from 'lib/queries/search';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.nextUrl);
-  const params: any = {};
+  const params: Record<string, string | null> = {};
   SEARCH_FIELDS.forEach((f) => {
     params[f] = searchParams.get(f);
   });
@@ -13,21 +12,7 @@ export async function GET(req: NextRequest) {
     params[f] = searchParams.get(f);
   });
 
-  const isCross = CROSS_FIELDS.some((f) => params[f]);
-
-  const condx = isCross
-    ? makeCrossQuery(params)
-    : SEARCH_FIELDS.map((f) => {
-        if (params[f]) {
-          return formatClause(f, params[f]);
-        }
-      })
-        .filter((c) => c)
-        .join(' and ');
-
-  const json = await query(
-    `SELECT * FROM rhs WHERE epithet != '' AND ${condx} order by date_of_registration desc limit 1000`
-  );
+  const json = await querySearch(params);
 
   return NextResponse.json(json, { status: 200 });
 }

--- a/lib/fetchers/grex-child.ts
+++ b/lib/fetchers/grex-child.ts
@@ -9,8 +9,3 @@ export const grexChildFetcher = (s: string, p: string) =>
   )
     .then((res) => res.json())
     .then((json) => json ?? null);
-
-export const fetchGrexChild = async (s: string, p: string): Promise<Grex[]> => {
-  const grex = await grexChildFetcher(s, p);
-  return grex;
-};

--- a/lib/fetchers/grex.ts
+++ b/lib/fetchers/grex.ts
@@ -5,8 +5,3 @@ export const grexFetcher = (id: string) =>
   fetch(`${APP_URL}/api/grex?id=${encodeURIComponent(id)}`)
     .then((res) => res.json())
     .then((json) => json ?? []);
-
-export const fetchGrex = async (id: string): Promise<Grex[]> => {
-  const grex = await grexFetcher(id);
-  return grex;
-};

--- a/lib/queries/grex.ts
+++ b/lib/queries/grex.ts
@@ -1,0 +1,16 @@
+import { ID_FIELDS, SEARCH_FIELDS } from 'lib/constants';
+import { query } from 'lib/storage/pg';
+import { Grex } from 'lib/types';
+
+export const queryGrexById = (id: string): Promise<Grex[]> => {
+  return query(
+    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(', ')} FROM rhs WHERE id = ANY('{${id}}'::text[])`
+  );
+};
+
+export const queryGrexChild = (s: string, p: string): Promise<Grex[]> => {
+  const idArrayItems = [s, p].join(',');
+  return query(
+    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(', ')} FROM rhs WHERE seed_parent_id = ANY('{${idArrayItems}}'::text[]) AND pollen_parent_id = ANY('{${idArrayItems}}'::text[])`
+  );
+};

--- a/lib/queries/registrant.ts
+++ b/lib/queries/registrant.ts
@@ -1,0 +1,13 @@
+import { ID_FIELDS, SEARCH_FIELDS } from 'lib/constants';
+import { query } from 'lib/storage/pg';
+import { Grex } from 'lib/types';
+
+export const queryRegistrant = (name: string): Promise<Grex[]> => {
+  const r = name.replace(/'/g, "''");
+
+  if (!r) return Promise.resolve([]);
+
+  return query(
+    `SELECT ${ID_FIELDS.join(', ')}, ${SEARCH_FIELDS.join(', ')} FROM rhs WHERE epithet != '' AND (registrant_name = '${r}' OR originator_name = '${r}') ORDER BY date_of_registration DESC`
+  );
+};

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -1,0 +1,22 @@
+import { SEARCH_FIELDS, CROSS_FIELDS } from 'lib/constants';
+import { formatClause, makeCrossQuery } from 'lib/utils';
+import { query } from 'lib/storage/pg';
+import { Grex } from 'lib/types';
+
+export const querySearch = (params: Record<string, string | null>): Promise<Grex[]> => {
+  const isCross = CROSS_FIELDS.some((f) => params[f]);
+
+  const condx = isCross
+    ? makeCrossQuery(params)
+    : SEARCH_FIELDS.map((f) => {
+        if (params[f]) {
+          return formatClause(f, params[f]);
+        }
+      })
+        .filter((c) => c)
+        .join(' and ');
+
+  return query(
+    `SELECT * FROM rhs WHERE epithet != '' AND ${condx} ORDER BY date_of_registration DESC LIMIT 1000`
+  );
+};


### PR DESCRIPTION
## Summary
- Extract shared query functions into `lib/queries/{grex,registrant,search}.ts`
- API routes and server-side fetchers now share a single source of truth for query logic
- Server components query PostgreSQL directly instead of making HTTP round-trips to their own API routes
- Client-side HTTP fetchers (`grexFetcher`, `grexChildFetcher`) preserved for SWR hooks

## Test plan
- [ ] Verify grex detail pages render correctly
- [ ] Verify registrant pages render correctly
- [ ] Verify hybridize page works with seed/pollen parent lookups
- [ ] Verify API routes (`/api/grex`, `/api/grexChild`, `/api/search`, `/api/registrant/[name]`) still return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)